### PR TITLE
ci: repin katzenpost to merge-pr-995-onto-main tip (1262d3bb)

### DIFF
--- a/.github/workflows/test-integration-docker.yml
+++ b/.github/workflows/test-integration-docker.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: katzenpost/katzenpost
-          ref: dbc7702a92716b542b0f77c8e824fc8e73420c29
+          ref: 1262d3bb405c687563933295fc6c6c5f3e6ef81a
           path: katzenpost
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
Update the katzenpost ref consumed by the docker-mixnet integration workflow from dbc7702a (some months stale) to 1262d3bb, the present tip of the merge-pr-995-onto-main branch. The prior pin had drifted sufficiently far behind the daemon code our recent thin client work targets that test runs were exercising a daemon out of step with client expectations.