### PR TITLE
Bump Rust and Python package versions to 0.0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "katzenpost_thin_client"
-version = "0.0.11"
+version = "0.0.15"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "katzenpost_thin_client"
-version = "0.0.11"
+version = "0.0.15"
 edition = "2024"
 authors = ["David Stainton"]
 homepage = "https://katzenpost.network"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "katzenpost_thinclient"
-version = "0.0.11"
+version = "0.0.15"
 dynamic = ["dependencies"]
 authors = [
   { name="David Stainton", email="dstainton415@gmail.com" },


### PR DESCRIPTION
The manifests still read 0.0.11 while the latest release tag is 0.0.14, so the next published version is 0.0.15. Cargo.toml, pyproject.toml, and the crate's own Cargo.lock entry are bumped together. This must precede cargo publish and the PyPI build, since both registries are immutable and reject re-uploading an existing version.