### PR TITLE
core: bound the daemon frame size before allocation

### DIFF
--- a/katzenpost_thinclient/core.py
+++ b/katzenpost_thinclient/core.py
@@ -27,6 +27,15 @@ from typing import Tuple, Any, Dict, List, Callable
 
 from .transport import DialConfig, TcpDialConfig, UnixDialConfig
 
+# Upper bound on a single length-prefixed frame from the daemon. The
+# 4-byte big-endian prefix is daemon-controlled; without a ceiling a
+# hostile or buggy daemon could declare a multi-gigabyte frame and
+# drive this client to allocate it before any payload arrives. 16 MiB
+# is far above any legitimate CBOR message yet far below a
+# memory-exhaustion threat. Must match the Go daemon's
+# thin.MaxMessageSize.
+MAX_MESSAGE_SIZE = 16 * 1024 * 1024
+
 # Pigeonhole Replica Error Codes (matching Go pigeonhole/errors.go)
 # These are error codes returned by storage replicas, passed through by the daemon
 # for the StartResendingEncryptedMessage API.
@@ -1015,6 +1024,10 @@ class ThinClient:
         async with self._recv_lock:
           length_prefix = await self.__recv_exactly(4, loop)
           message_length = struct.unpack('>I', length_prefix)[0]
+          if message_length > MAX_MESSAGE_SIZE:
+              raise ValueError(
+                  f"daemon response frame too large: {message_length} bytes "
+                  f"(max {MAX_MESSAGE_SIZE})")
           raw_data = await self.__recv_exactly(message_length, loop)
         try:
           response = cbor2.loads(raw_data)

--- a/src/core.rs
+++ b/src/core.rs
@@ -59,6 +59,15 @@ const SURB_ID_SIZE: usize = 16;
 /// The size in bytes of a message identifier.
 const MESSAGE_ID_SIZE: usize = 16;
 
+/// Upper bound on a single length-prefixed frame from the daemon. The
+/// 4-byte big-endian prefix is daemon-controlled; without a ceiling a
+/// hostile or buggy daemon could declare a multi-gigabyte frame and
+/// drive this client to allocate it before any payload arrives. 16 MiB
+/// is far above any legitimate CBOR message yet far below a
+/// memory-exhaustion threat. Must match the Go daemon's
+/// thin.MaxMessageSize.
+const MAX_MESSAGE_SIZE: usize = 16 * 1024 * 1024;
+
 /// The size in bytes of a query identifier.
 const QUERY_ID_SIZE: usize = 16;
 
@@ -464,6 +473,12 @@ impl ThinClient {
                 };
         }
         let message_length = u32::from_be_bytes(length_prefix) as usize;
+        if message_length > MAX_MESSAGE_SIZE {
+            return Err(ThinClientError::Other(format!(
+                "daemon response frame too large: {} bytes (max {})",
+                message_length, MAX_MESSAGE_SIZE
+            )));
+        }
         let mut buffer = vec![0; message_length];
         {
                 let mut read_half = self.read_half.lock().await;


### PR DESCRIPTION
Sir, mirroring the daemon-side fix: the four-byte big-endian length prefix preceding each frame from the daemon was trusted verbatim and the declared length allocated before any payload was read. A hostile or buggy daemon could thus demand gigabytes from the client at will. Both the Rust and Python readers now reject any frame exceeding MAX_MESSAGE_SIZE (16 MiB, matching the Go daemon's thin.MaxMessageSize) before allocating.

Verified: cargo check clean; python syntax check clean.