### PR TITLE
add get_directory_authorities to rust and python clients

### DIFF
--- a/.github/workflows/test-integration-docker.yml
+++ b/.github/workflows/test-integration-docker.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: katzenpost/katzenpost
-          ref: 22a85f22ad59bf4da2ac4970a601987f781cf034
+          ref: adbcd4c0b9ed83438b4adb2a1b0a98812144c80c
           path: katzenpost
 
       - name: Set up Docker Buildx

--- a/katzenpost_thinclient/core.py
+++ b/katzenpost_thinclient/core.py
@@ -1312,6 +1312,48 @@ class ThinClient:
 
         return reply.get("payload"), returned_epoch
 
+    async def get_directory_authorities(self) -> "List[Dict[str,Any]]":
+        """
+        Return the directory authority descriptors the client daemon is
+        configured with.
+
+        A thin client holds only its dial transport configuration and
+        never sees the daemon's voting authority peer list. This surfaces
+        it, so a caller may, for instance, map a PKI document's signature
+        fingerprints (the keys of its signature map) to authority
+        identifiers via each descriptor's ``identity_key_hash``.
+
+        Returns:
+            List[Dict[str, Any]]: one dict per directory authority, with
+            keys ``identifier`` (str), ``pki_signature_scheme`` (str),
+            ``wire_kem_scheme`` (str), ``addresses`` (list of str),
+            ``identity_public_key_pem`` (str), ``link_public_key_pem``
+            (str), and ``identity_key_hash`` (32 raw bytes, the value by
+            which PKI document signatures are indexed).
+
+        Raises:
+            Exception: If the daemon has no voting authority peers
+                configured, or any other error code is returned.
+        """
+        query_id = self.new_query_id()
+
+        request = {
+            "get_directory_authorities": {
+                "query_id": query_id,
+            }
+        }
+
+        reply = await self._send_and_wait(query_id=query_id, request=request)
+
+        error_code = reply.get("error_code", 0)
+        if error_code != THIN_CLIENT_SUCCESS:
+            error_msg = thin_client_error_to_string(error_code)
+            raise Exception(
+                f"get_directory_authorities failed: {error_msg}"
+            )
+
+        return reply.get("authorities", [])
+
     def parse_pki_doc(self, event: "Dict[str,Any]") -> None:
         """
         Parse and store a new PKI document received from the daemon.

--- a/src/core.rs
+++ b/src/core.rs
@@ -53,6 +53,43 @@ struct GetPKIDocumentReply {
     error_code: u8,
 }
 
+/// A directory authority descriptor as held in the client daemon's
+/// configuration. The keys are conveyed in PEM so a consumer need not
+/// link a key type to read them; `identity_key_hash` is the 32-byte
+/// BLAKE2b-256 hash of the identity public key, the value by which a PKI
+/// document's signatures are indexed.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct DirectoryAuthority {
+    pub identifier: String,
+    pub pki_signature_scheme: String,
+    pub wire_kem_scheme: String,
+    pub addresses: Vec<String>,
+    pub identity_public_key_pem: String,
+    pub link_public_key_pem: String,
+    #[serde(with = "serde_bytes")]
+    pub identity_key_hash: Vec<u8>,
+}
+
+/// Request the directory authority descriptors the daemon is configured
+/// with. Carries only a correlation id; the daemon needs no parameters.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct GetDirectoryAuthoritiesRequest {
+    #[serde(with = "serde_bytes")]
+    query_id: Vec<u8>,
+}
+
+/// Reply to a `GetDirectoryAuthorities` request. `authorities` carries the
+/// descriptors; `error_code` is zero on success.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct GetDirectoryAuthoritiesReply {
+    #[serde(with = "serde_bytes")]
+    query_id: Vec<u8>,
+    #[serde(default)]
+    authorities: Vec<DirectoryAuthority>,
+    #[serde(default)]
+    error_code: u8,
+}
+
 /// The size in bytes of a SURB (Single-Use Reply Block) identifier.
 const SURB_ID_SIZE: usize = 16;
 
@@ -393,6 +430,53 @@ impl ThinClient {
         }
 
         Ok((reply.payload, reply.epoch))
+    }
+
+    /// Return the directory authority descriptors the client daemon is
+    /// configured with.
+    ///
+    /// A thin client holds only its dial transport configuration and never
+    /// sees the daemon's voting authority peer list. This surfaces it, so a
+    /// caller may, for instance, map a PKI document's signature fingerprints
+    /// (the keys of its signature map) to authority identifiers via each
+    /// descriptor's `identity_key_hash`.
+    ///
+    /// # Errors
+    ///
+    /// * `ThinClientError::Other` — the daemon has no voting authority peers
+    ///   configured, or any other non-zero error code is returned.
+    pub async fn get_directory_authorities(
+        &self,
+    ) -> Result<Vec<DirectoryAuthority>, ThinClientError> {
+        let query_id = Self::new_query_id();
+
+        let request_inner = GetDirectoryAuthoritiesRequest {
+            query_id: query_id.clone(),
+        };
+
+        let request_value = serde_cbor::value::to_value(&request_inner)
+            .map_err(ThinClientError::CborError)?;
+
+        let mut request = BTreeMap::new();
+        request.insert(
+            Value::Text("get_directory_authorities".to_string()),
+            request_value,
+        );
+
+        let reply_map = self.send_and_wait_direct(query_id, request).await?;
+
+        let reply: GetDirectoryAuthoritiesReply =
+            serde_cbor::value::from_value(Value::Map(reply_map))
+                .map_err(ThinClientError::CborError)?;
+
+        if reply.error_code != 0 {
+            return Err(ThinClientError::Other(format!(
+                "get_directory_authorities failed: error code {}",
+                reply.error_code
+            )));
+        }
+
+        Ok(reply.authorities)
     }
 
     /// Returns the pigeonhole geometry the daemon supplied during the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ pub mod transport;
 // Re-exports for public API
 // ========================================================================
 
-pub use crate::core::{ThinClient, EventSinkReceiver};
+pub use crate::core::{ThinClient, EventSinkReceiver, DirectoryAuthority};
 pub use crate::error::ThinClientError;
 pub use crate::helpers::{find_services, pretty_print_pki_doc};
 pub use crate::pigeonhole::{TombstoneRangeResult, StartResendingResult};

--- a/tests/directory_authorities_test.rs
+++ b/tests/directory_authorities_test.rs
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: Copyright (C) 2026 David Stainton
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Integration test for `get_directory_authorities`.
+//!
+//! Requires a running mixnet with a client daemon, as the method is a
+//! round-trip to the daemon for its configured voting authority peers.
+
+use std::time::Duration;
+
+use katzenpost_thin_client::{Config, ThinClient};
+
+async fn setup_thin_client() -> Result<std::sync::Arc<ThinClient>, Box<dyn std::error::Error>> {
+    let config = Config::new("testdata/thinclient.toml")?;
+    let client = ThinClient::new(config).await?;
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    Ok(client)
+}
+
+#[tokio::test]
+async fn test_get_directory_authorities() {
+    let client = setup_thin_client()
+        .await
+        .expect("Failed to setup client");
+
+    let authorities = client
+        .get_directory_authorities()
+        .await
+        .expect("get_directory_authorities should succeed");
+
+    assert!(
+        !authorities.is_empty(),
+        "daemon should report its configured directory authorities"
+    );
+
+    for authority in &authorities {
+        assert!(
+            !authority.identifier.is_empty(),
+            "every authority must have an identifier"
+        );
+        assert_eq!(
+            authority.identity_key_hash.len(),
+            32,
+            "identity_key_hash must be a 32-byte fingerprint for {}",
+            authority.identifier
+        );
+        assert!(
+            !authority.identity_public_key_pem.is_empty(),
+            "every authority must carry its identity public key in PEM"
+        );
+        println!(
+            "authority {} fingerprint {}",
+            authority.identifier,
+            hex::encode(&authority.identity_key_hash)
+        );
+    }
+}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -71,6 +71,41 @@ async def test_thin_client_send_receive_integration_test():
 
 
 @pytest.mark.asyncio
+async def test_get_directory_authorities_integration_test():
+    """Test that get_directory_authorities returns the daemon's configured peers."""
+    from .conftest import is_daemon_available
+
+    if not is_daemon_available():
+        pytest.skip("Katzenpost client daemon not available")
+    from .conftest import get_config_path
+
+    config_path = get_config_path()
+    assert os.path.exists(config_path), f"Missing config file: {config_path}"
+
+    cfg = Config(config_path)
+    client = ThinClient(cfg)
+    loop = asyncio.get_event_loop()
+
+    try:
+        await client.start(loop)
+
+        authorities = await client.get_directory_authorities()
+        assert len(authorities) > 0, "daemon should report its configured directory authorities"
+
+        for authority in authorities:
+            assert authority.get("identifier"), "every authority must have an identifier"
+            key_hash = authority.get("identity_key_hash")
+            assert isinstance(key_hash, bytes) and len(key_hash) == 32, \
+                f"identity_key_hash must be a 32-byte fingerprint for {authority.get('identifier')}"
+            assert authority.get("identity_public_key_pem"), \
+                "every authority must carry its identity public key in PEM"
+            print(f"authority {authority['identifier']} fingerprint {key_hash.hex()}")
+
+    finally:
+        client.stop()
+
+
+@pytest.mark.asyncio
 async def test_config_validation():
     """Test configuration validation and error handling."""
     from .conftest import get_config_path


### PR DESCRIPTION
Bumps the katzenpost CI pin to adbcd4c0, which implements the request.