### PR TITLE
Remove the client-side courier getters

### DIFF
--- a/katzenpost_thinclient/core.py
+++ b/katzenpost_thinclient/core.py
@@ -1464,55 +1464,6 @@ class ThinClient:
         service_descriptors = self.get_services(service_name)
         return random.choice(service_descriptors)
 
-    def get_all_couriers(self) -> "List[Tuple[bytes, bytes]]":
-        """
-        Return every courier service advertised in the current PKI
-        document, each described by an ``(identity_hash, queue_id)``
-        tuple. The list reflects only the couriers that the current
-        consensus regards as serving.
-
-        The principal caller is the nested-copy-command machinery, which
-        needs to choose particular couriers rather than accept the random
-        draw made on the caller's behalf by
-        ``start_resending_copy_command``; for simple cases where any
-        courier will do, the default routing path is usually preferable.
-
-        Returns:
-            list[tuple[bytes, bytes]]: List of (identity_hash, queue_id) tuples.
-
-        Raises:
-            Exception: If no couriers are available.
-        """
-        services = self.get_services("courier")
-        couriers = []
-        for svc in services:
-            identity_hash = blake2_256_sum(svc.mix_descriptor['IdentityKey'])
-            couriers.append((identity_hash, svc.recipient_queue_id))
-        return couriers
-
-    def get_distinct_couriers(self, n:int) -> "List[Tuple[bytes, bytes]]":
-        """
-        Draw ``n`` couriers uniformly at random from the list returned by
-        ``get_all_couriers``, without replacement, so that no two entries
-        in the returned list refer to the same courier. This is the usual
-        building block for a nested copy command, every layer of which
-        must be carried by a different courier.
-
-        Args:
-            n (int): Number of distinct couriers to return.
-
-        Returns:
-            list[tuple[bytes, bytes]]: List of (identity_hash, queue_id) tuples.
-
-        Raises:
-            Exception: If the current PKI document advertises fewer than
-                ``n`` couriers.
-        """
-        couriers = self.get_all_couriers()
-        if len(couriers) < n:
-            raise Exception("not enough couriers available")
-        return random.sample(couriers, n)
-
     async def blocking_send_message(self, payload:bytes|str, dest_node:bytes, dest_queue:bytes, timeout_seconds:float=30.0) -> bytes:
         """
         Send a message and block until a reply is received or timeout.

--- a/src/core.rs
+++ b/src/core.rs
@@ -17,7 +17,6 @@ use tokio::net::unix::{OwnedReadHalf as UnixReadHalf, OwnedWriteHalf as UnixWrit
 
 use rand::RngCore;
 use rand::Rng;
-use rand::seq::SliceRandom;
 use log::{debug, error};
 
 use crate::error::ThinClientError;
@@ -618,72 +617,6 @@ impl ThinClient {
         let idx = rand::thread_rng().gen_range(0..services.len());
         Ok(services.swap_remove(idx))
     }
-
-    /// Returns every courier service advertised in the current PKI
-    /// document, each as the `(identity_hash, queue_id)` pair the rest of
-    /// the API expects.
-    ///
-    /// The principal caller is the nested-copy-command machinery, which
-    /// must choose particular couriers rather than accept the random draw
-    /// made on its behalf by `start_resending_copy_command`; for simple
-    /// cases where any courier will do, the default routing path is
-    /// usually preferable.
-    ///
-    /// # Errors
-    ///
-    /// * `ThinClientError::MissingPkiDocument` — no PKI document is yet
-    ///   available; see `pki_document`.
-    /// * `ThinClientError::ServiceNotFound` — the current consensus
-    ///   advertises no courier.
-    pub async fn get_all_couriers(&self) -> Result<Vec<(Vec<u8>, Vec<u8>)>, ThinClientError> {
-        let services = self.get_services("courier").await?;
-        Ok(services.iter().map(|svc| svc.to_destination()).collect())
-    }
-
-    /// Draws `n` couriers uniformly at random from `get_all_couriers`,
-    /// without replacement, so that no two entries in the returned list
-    /// refer to the same courier. This is the usual building block for a
-    /// nested copy command, every layer of which must be carried by a
-    /// different courier.
-    ///
-    /// # Arguments
-    ///
-    /// * `n` — the number of distinct couriers to return.
-    ///
-    /// # Errors
-    ///
-    /// * `ThinClientError::MissingPkiDocument` / `ServiceNotFound` — as
-    ///   for `get_all_couriers`.
-    /// * `ThinClientError::Other` — the current consensus advertises fewer
-    ///   than `n` couriers.
-    pub async fn get_distinct_couriers(&self, n: usize) -> Result<Vec<(Vec<u8>, Vec<u8>)>, ThinClientError> {
-        let couriers = self.get_all_couriers().await?;
-        if couriers.len() < n {
-            return Err(ThinClientError::Other(format!(
-                "not enough couriers available: requested {}, have {}",
-                n,
-                couriers.len()
-            )));
-        }
-        Ok(couriers
-            .choose_multiple(&mut rand::thread_rng(), n)
-            .cloned()
-            .collect())
-    }
-
-    /// Returns one courier destination, drawn uniformly at random from
-    /// the couriers advertised in the current PKI document, as the
-    /// `(identity_hash, queue_id)` pair the rest of the API expects. This
-    /// spares the caller from handling a list when one courier will do.
-    ///
-    /// For the nested-copy-command case where two distinct couriers are
-    /// required, use `get_distinct_couriers` rather than calling this
-    /// method twice and risking the same draw.
-    pub async fn get_courier_destination(&self) -> Result<(Vec<u8>, Vec<u8>), ThinClientError> {
-        let mut couriers = self.get_distinct_couriers(1).await?;
-        Ok(couriers.swap_remove(0))
-    }
-
 
     pub(crate) async fn recv(&self) -> Result<BTreeMap<Value, Value>, ThinClientError> {
         let mut length_prefix = [0; 4];

--- a/tests/test_new_methods.py
+++ b/tests/test_new_methods.py
@@ -2,34 +2,16 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 """
-Unit tests for new ThinClient methods: get_all_couriers, get_distinct_couriers,
-pki_document_for_epoch, and blocking_send_message.
+Unit tests for new ThinClient methods: pki_document_for_epoch and
+blocking_send_message.
 
 These tests mock the PKI document and do not require a running daemon.
 """
 
 import pytest
-import hashlib
 import cbor2
 
 from katzenpost_thinclient import ThinClient, Config
-
-
-def blake2_256_sum(data: bytes) -> bytes:
-    return hashlib.blake2b(data, digest_size=32).digest()
-
-
-def make_service_node(identity_key: bytes, capability: str, endpoint: str) -> bytes:
-    """Create a CBOR-encoded service node descriptor."""
-    node = {
-        "IdentityKey": identity_key,
-        "Kaetzchen": {
-            capability: {
-                "endpoint": endpoint,
-            }
-        }
-    }
-    return cbor2.dumps(node)
 
 
 def make_pki_doc(service_nodes: list, epoch: int = 1) -> dict:
@@ -48,89 +30,6 @@ def make_client() -> ThinClient:
     config_path = get_config_path()
     cfg = Config(config_path)
     return ThinClient(cfg)
-
-
-class TestGetAllCouriers:
-
-    def test_returns_couriers(self):
-        client = make_client()
-        key1 = b"courier_identity_key_1__________"
-        key2 = b"courier_identity_key_2__________"
-        nodes = [
-            make_service_node(key1, "courier", "courier"),
-            make_service_node(key2, "courier", "courier"),
-        ]
-        client.pki_doc = make_pki_doc(nodes)
-
-        couriers = client.get_all_couriers()
-
-        assert len(couriers) == 2
-        assert couriers[0] == (blake2_256_sum(key1), b"courier")
-        assert couriers[1] == (blake2_256_sum(key2), b"courier")
-        client.socket.close()
-
-    def test_no_couriers_raises(self):
-        client = make_client()
-        nodes = [
-            make_service_node(b"echo_key________________________", "echo", "echo"),
-        ]
-        client.pki_doc = make_pki_doc(nodes)
-
-        with pytest.raises(Exception, match="service not found"):
-            client.get_all_couriers()
-        client.socket.close()
-
-    def test_no_pki_doc_raises(self):
-        client = make_client()
-        client.pki_doc = None
-
-        with pytest.raises(Exception, match="pki doc is nil"):
-            client.get_all_couriers()
-        client.socket.close()
-
-
-class TestGetDistinctCouriers:
-
-    def test_returns_n_distinct(self):
-        client = make_client()
-        keys = [f"courier_key_{i:021d}".encode() for i in range(5)]
-        nodes = [make_service_node(k, "courier", "courier") for k in keys]
-        client.pki_doc = make_pki_doc(nodes)
-
-        result = client.get_distinct_couriers(3)
-
-        assert len(result) == 3
-        # All should be distinct
-        hashes = [r[0] for r in result]
-        assert len(set(hashes)) == 3
-        # All should be valid courier hashes
-        valid_hashes = {blake2_256_sum(k) for k in keys}
-        for h in hashes:
-            assert h in valid_hashes
-        client.socket.close()
-
-    def test_not_enough_couriers_raises(self):
-        client = make_client()
-        nodes = [
-            make_service_node(b"courier_key_only________________", "courier", "courier"),
-        ]
-        client.pki_doc = make_pki_doc(nodes)
-
-        with pytest.raises(Exception, match="not enough couriers"):
-            client.get_distinct_couriers(3)
-        client.socket.close()
-
-    def test_exact_count(self):
-        client = make_client()
-        keys = [f"courier_key_{i:021d}".encode() for i in range(2)]
-        nodes = [make_service_node(k, "courier", "courier") for k in keys]
-        client.pki_doc = make_pki_doc(nodes)
-
-        result = client.get_distinct_couriers(2)
-
-        assert len(result) == 2
-        assert len(set(r[0] for r in result)) == 2
-        client.socket.close()
 
 
 class TestPkiDocumentForEpoch:


### PR DESCRIPTION
The daemon owns courier selection and pins it across the two-phase ARQ receive and every retry, so a thin-client courier getter influences nothing: StartResendingEncryptedMessage carries no courier field. get_all_couriers, get_distinct_couriers, and get_courier_destination were leftovers from a pre-daemon-ARQ design; drop all three from the Rust and Python bindings and their tests.